### PR TITLE
fix: Cordova iOS7.0.0 dropped support of podspec type from framework tag

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -93,7 +93,14 @@
 
         <dependency id="scandit-cordova-datacapture-core" version="6.18.1" />
 
-        <framework src="ScanditBarcodeCapture" spec="= 6.18.1" type="podspec" />
+        <podspec>
+			<config>
+				<source url="https://cdn.cocoapods.org/"/>
+			</config>
+			<pods use-frameworks="true">
+				<pod name="ScanditBarcodeCapture" spec="6.18.1"/>
+			</pods>
+		</podspec>
     </platform>
 
     <!-- Android -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -91,8 +91,6 @@
         <source-file src="src/ios/TappableBase64ImageView.swift" />
         <source-file src="src/ios/CommandJSONArgument+ScanditBarcodeCapture.swift" />
 
-        <dependency id="scandit-cordova-datacapture-core" version="6.18.1" />
-
         <podspec>
 			<config>
 				<source url="https://cdn.cocoapods.org/"/>


### PR DESCRIPTION
fix: Cordova iOS7.0.0 dropped support of podspec type from framework tag